### PR TITLE
manual

### DIFF
--- a/src/components/quest/context.jsx
+++ b/src/components/quest/context.jsx
@@ -22,6 +22,8 @@ const QuestProvider = ({ children, initialWorldsData }) => {
   const [levelFull, setLevelFull] = React.useState(false);
   const [descriptionFull, setDescriptionFull] = React.useState(false);
 
+  const [manualOpen, setManualOpen] = React.useState(false);
+
   React.useEffect(
     function setFullScreenOnMobile() {
       if (isMobile) {
@@ -167,6 +169,8 @@ const QuestProvider = ({ children, initialWorldsData }) => {
         setLevelFull,
         descriptionFull,
         setDescriptionFull,
+        manualOpen,
+        setManualOpen,
       }}
     >
       {children}

--- a/src/components/quest/manual.jsx
+++ b/src/components/quest/manual.jsx
@@ -10,21 +10,18 @@ import {
   AccordionTrigger,
   AccordionContent,
 } from "@/components/ui/accordion";
-import { GripVertical, X, Move, CornerDownRight, BookOpen } from "lucide-react";
+import { GripVertical, X, CornerDownRight, BookOpen } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Textarea } from "@/components/ui/textarea";
+import LevelDescription from "./level-description";
+import { useMobile } from "@/hooks/use-mobile";
 
-const ResizeHandle = ({
-  width = "12",
-  height = "12",
-  fill = "currentColor",
-  className,
-}) => (
+const ResizeHandle = ({ width = "12", height = "12", className }) => (
   <svg
     width={width}
     height={height}
     viewBox={`0 0 ${width} ${height}`}
-    className="text-gray-400"
+    className={cn("text-foreground", className)}
   >
     <path
       d="M8 12H12V8L8 12ZM4 12H6L12 6V4L4 12ZM0 12H2L12 2V0L0 12Z"
@@ -70,6 +67,7 @@ const setManualWindowState = (state) => {
 };
 
 export const Manual = ({ open, onOpenChange }) => {
+  const isMobile = useMobile();
   const { worldsData, selectedWorld, selectedLevelName } =
     useContext(QuestContext);
 
@@ -241,35 +239,55 @@ export const Manual = ({ open, onOpenChange }) => {
       id="leetquest-manual-window"
       className={cn(
         "fixed z-[100] transition-transform duration-100 shadow shadow-black/75 border border-[--surface-2] bg-[--surface-1] rounded-xl flex flex-col",
-        dragging &&
+        !isMobile &&
+          dragging &&
           "shadow-black/75 shadow-md scale-[1.01] motion-reduce:scale-100",
+        isMobile && "left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2",
       )}
-      style={{
-        left: position.x,
-        top: position.y,
-        width: size.width,
-        height: size.height,
-        minWidth: 320,
-        minHeight: 320,
-        maxWidth: "90vw",
-        maxHeight: "90vh",
-      }}
+      style={
+        isMobile
+          ? {
+              left: "50%",
+              top: "50%",
+              width: "95vw",
+              height: "90vh",
+              minWidth: 0,
+              minHeight: 0,
+              maxWidth: "95vw",
+              maxHeight: "90vh",
+            }
+          : {
+              left: position.x,
+              top: position.y,
+              width: size.width,
+              height: size.height,
+              minWidth: 320,
+              minHeight: 320,
+              maxWidth: "90vw",
+              maxHeight: "90vh",
+            }
+      }
     >
       <header
         className={cn(
-          "flex items-center justify-between px-4 py-2 border-b border-[--surface-2] cursor-grab select-none bg-[--surface-1] rounded-t-xl",
-          dragging && "cursor-grabbing",
+          "flex items-center justify-between px-4 sm:px-6 py-2 border-b border-[--surface-2] select-none bg-[--surface-1] rounded-t-xl",
+          !isMobile && "cursor-grab",
+          !isMobile && dragging && "cursor-grabbing",
         )}
-        onMouseDown={(e) => {
-          setDragging(true);
-          dragStart.current = {
-            x: e.clientX - positionRef.current.x,
-            y: e.clientY - positionRef.current.y,
-          };
-        }}
+        {...(!isMobile && {
+          onMouseDown: (e) => {
+            setDragging(true);
+            dragStart.current = {
+              x: e.clientX - positionRef.current.x,
+              y: e.clientY - positionRef.current.y,
+            };
+          },
+        })}
       >
         <h2 className="flex gap-2 items-center text-lg font-semibold">
-          <GripVertical className="mr-1 w-4 h-4 text-muted-foreground" />
+          {!isMobile && (
+            <GripVertical className="mr-1 w-4 h-4 text-muted-foreground" />
+          )}
           Manual
         </h2>
         <Button
@@ -281,7 +299,7 @@ export const Manual = ({ open, onOpenChange }) => {
           <X className="w-5 h-5" />
         </Button>
       </header>
-      <main className="overflow-y-auto flex-1 p-4 space-y-6">
+      <main className="overflow-y-auto flex-1 py-4 px-4 space-y-6 sm:px-6">
         {unlockedWorlds.length === 0 && (
           <p className="py-8 text-center text-muted-foreground">
             No unlocked worlds yet.
@@ -298,7 +316,7 @@ export const Manual = ({ open, onOpenChange }) => {
             <AccordionItem
               key={world.id}
               value={world.name}
-              className="mb-2 rounded-lg border-none bg-[--surface-2]"
+              className="mb-2 rounded-md border-none bg-[--surface-2]"
               ref={(el) => {
                 if (el) worldRefs.current[world.name] = el;
               }}
@@ -338,21 +356,20 @@ export const Manual = ({ open, onOpenChange }) => {
                           if (el) levelRefs.current[level.name] = el;
                         }}
                       >
-                        <AccordionTrigger className="py-1 px-2 font-medium rounded">
+                        <AccordionTrigger className="py-1 px-2 font-semibold rounded">
                           <span className="flex gap-2 items-center">
                             <CornerDownRight className="w-4 h-4 text-muted-foreground" />
                             {level.title || level.name}
                           </span>
                         </AccordionTrigger>
                         <AccordionContent>
-                          <div
-                            dangerouslySetInnerHTML={{
-                              __html: level.description,
-                            }}
-                            className="px-6 pt-4 text-sm text-muted-foreground"
-                          ></div>
+                          <LevelDescription
+                            className="py-4 px-6 text-sm prose"
+                            rawHtml={level.description}
+                            skipCode
+                          />
                           <Textarea
-                            className="block mx-6 w-[calc(100%-3rem)]"
+                            className="block mx-6 w-[calc(100%-3rem)] placeholder:text-background placeholder:opacity-70 border-[--surface-2] bg-[--light] text-background"
                             placeholder="Your notes..."
                             value={notes[level.id] || ""}
                             onChange={(e) =>
@@ -369,21 +386,23 @@ export const Manual = ({ open, onOpenChange }) => {
           ))}
         </Accordion>
       </main>
-      <div
-        className="flex absolute right-1 bottom-1 z-10 justify-center items-center w-6 h-6 cursor-se-resize"
-        onMouseDown={(e) => {
-          setResizing(true);
-          sizeStart.current = {
-            width: sizeRef.current.width,
-            height: sizeRef.current.height,
-            x: e.clientX,
-            y: e.clientY,
-          };
-          e.stopPropagation();
-        }}
-      >
-        <ResizeHandle />
-      </div>
+      {!isMobile && (
+        <div
+          className="flex absolute right-0 bottom-0 z-10 justify-center items-center w-6 h-6 cursor-se-resize"
+          onMouseDown={(e) => {
+            setResizing(true);
+            sizeStart.current = {
+              width: sizeRef.current.width,
+              height: sizeRef.current.height,
+              x: e.clientX,
+              y: e.clientY,
+            };
+            e.stopPropagation();
+          }}
+        >
+          <ResizeHandle />
+        </div>
+      )}
     </article>
   );
 };

--- a/src/components/quest/problem-preview.jsx
+++ b/src/components/quest/problem-preview.jsx
@@ -9,6 +9,7 @@ import { setLevelComplete } from "./fetch-data";
 import { cn } from "@/lib/utils";
 import { CheckCircle2, Circle, Play } from "lucide-react";
 import LevelDescription from "./level-description";
+import { ButtonsContainer, CloseButton, ResizeButton } from "./quest";
 
 const ProblemPreview = () => {
   const {
@@ -17,6 +18,8 @@ const ProblemPreview = () => {
     setWorldsData,
     setSelectedWorldData,
     closeLevel,
+    descriptionFull,
+    setDescriptionFull,
   } = React.useContext(QuestContext);
   const [loading, setLoading] = React.useState(false);
 
@@ -75,7 +78,17 @@ const ProblemPreview = () => {
             levelStatus={selectedLevelData.status}
           />
         )}
-        <h2 className="w-2/3 text-2xl">{selectedLevelData.title}</h2>
+        <h2 className="w-2/3 text-2xl font-semibold">
+          {selectedLevelData.title}
+        </h2>
+        <ButtonsContainer className="top-1/2 -translate-y-1/2">
+          <ResizeButton
+            onClick={() => setDescriptionFull((prev) => !prev)}
+            open={descriptionFull}
+            className="hidden md:block"
+          />
+          <CloseButton onClick={closeLevel} />
+        </ButtonsContainer>
       </header>
 
       <LevelDescription

--- a/src/components/quest/problem-preview.jsx
+++ b/src/components/quest/problem-preview.jsx
@@ -5,11 +5,16 @@ import { Button } from "@/components/ui/button";
 import { Loading } from "@/components/ui/spinner";
 import { QuestContext } from "@/components/quest/context";
 import { WorldNode } from "@/components/quest/world";
-import { setLevelComplete } from "./fetch-data";
+import { setLevelComplete } from "@/components/quest/fetch-data";
 import { cn } from "@/lib/utils";
 import { CheckCircle2, Circle, Play } from "lucide-react";
-import LevelDescription from "./level-description";
-import { ButtonsContainer, CloseButton, ResizeButton } from "./quest";
+import LevelDescription from "@/components/quest/level-description";
+import {
+  ButtonsContainer,
+  CloseButton,
+  ManualButton,
+  ResizeButton,
+} from "@/components/quest/quest";
 
 const ProblemPreview = () => {
   const {
@@ -20,6 +25,8 @@ const ProblemPreview = () => {
     closeLevel,
     descriptionFull,
     setDescriptionFull,
+    manualOpen,
+    setManualOpen,
   } = React.useContext(QuestContext);
   const [loading, setLoading] = React.useState(false);
 
@@ -82,6 +89,10 @@ const ProblemPreview = () => {
           {selectedLevelData.title}
         </h2>
         <ButtonsContainer className="top-1/2 -translate-y-1/2">
+          <ManualButton
+            open={manualOpen}
+            onClick={() => setManualOpen((prev) => !prev)}
+          />
           <ResizeButton
             onClick={() => setDescriptionFull((prev) => !prev)}
             open={descriptionFull}

--- a/src/components/quest/quest.jsx
+++ b/src/components/quest/quest.jsx
@@ -9,7 +9,7 @@ import { cn } from "@/lib/utils";
 import { CircleX, Expand, Minimize, BookOpen } from "lucide-react";
 import { Manual } from "./manual";
 
-const ButtonsContainer = ({ children, className }) => {
+export const ButtonsContainer = ({ children, className }) => {
   return (
     <nav
       className={cn(
@@ -26,7 +26,7 @@ ButtonsContainer.propTypes = {
   className: PropTypes.string,
 };
 
-const ResizeButton = ({ onClick, className, open }) => {
+export const ResizeButton = ({ onClick, className, open }) => {
   if (open) {
     return (
       <Minimize
@@ -56,7 +56,7 @@ ResizeButton.propTypes = {
   open: PropTypes.bool.isRequired,
 };
 
-const CloseButton = ({ onClick, className }) => {
+export const CloseButton = ({ onClick, className }) => {
   return (
     <CircleX
       onClick={onClick}
@@ -82,10 +82,9 @@ export const Quest = () => {
     descriptionFull,
     setDescriptionFull,
     closeWorld,
-    closeLevel,
   } = useContext(QuestContext);
 
-  const [manualOpen, setManualOpen] = useState(false);
+  const [manualOpen, setManualOpen] = useState(true);
 
   return (
     <section>
@@ -127,14 +126,6 @@ export const Quest = () => {
               )}
             >
               <ProblemPreview />
-              <ButtonsContainer className="top-6">
-                <ResizeButton
-                  onClick={() => setDescriptionFull((prev) => !prev)}
-                  open={descriptionFull}
-                  className="hidden md:block"
-                />
-                <CloseButton onClick={closeLevel} />
-              </ButtonsContainer>
             </section>
           )}
           <World worldData={selectedWorldData} isAWorld={true} />

--- a/src/components/quest/quest.jsx
+++ b/src/components/quest/quest.jsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useContext, useState } from "react";
+import { useContext } from "react";
 import PropTypes from "prop-types";
 import { World } from "@/components/quest/world";
 import { QuestContext } from "@/components/quest/context";
-import ProblemPreview from "./problem-preview";
+import ProblemPreview from "@/components/quest/problem-preview";
 import { cn } from "@/lib/utils";
-import { CircleX, Expand, Minimize, BookOpen } from "lucide-react";
-import { Manual } from "./manual";
+import { CircleX, Expand, Minimize, BookOpen, Book } from "lucide-react";
+import { Manual } from "@/components/quest/manual";
 
 export const ButtonsContainer = ({ children, className }) => {
   return (
@@ -30,6 +30,7 @@ export const ResizeButton = ({ onClick, className, open }) => {
   if (open) {
     return (
       <Minimize
+        title="Minimize"
         onClick={onClick}
         className={cn(
           "w-6 h-6 ease-in-out cursor-pointer",
@@ -41,6 +42,7 @@ export const ResizeButton = ({ onClick, className, open }) => {
   }
   return (
     <Expand
+      aria-label="Maximize"
       onClick={onClick}
       className={cn(
         "w-[22px] h-[22px] cursor-pointer",
@@ -59,12 +61,41 @@ ResizeButton.propTypes = {
 export const CloseButton = ({ onClick, className }) => {
   return (
     <CircleX
+      aria-label="Close"
       onClick={onClick}
       className={cn("w-6 h-6 cursor-pointer", "hover:text-primary", className)}
     />
   );
 };
 CloseButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  className: PropTypes.string,
+};
+
+export const ManualButton = ({ open, onClick, className }) => {
+  if (open) {
+    return (
+      <Book
+        aria-label="Close Manual"
+        onClick={onClick}
+        className={cn(
+          "w-6 h-6 cursor-pointer",
+          "hover:text-primary",
+          className,
+        )}
+      />
+    );
+  }
+  return (
+    <BookOpen
+      aria-label="Open Manual"
+      onClick={onClick}
+      className={cn("w-6 h-6 cursor-pointer", "hover:text-primary", className)}
+    />
+  );
+};
+ManualButton.propTypes = {
+  open: PropTypes.bool.isRequired,
   onClick: PropTypes.func.isRequired,
   className: PropTypes.string,
 };
@@ -82,20 +113,12 @@ export const Quest = () => {
     descriptionFull,
     setDescriptionFull,
     closeWorld,
+    manualOpen,
+    setManualOpen,
   } = useContext(QuestContext);
-
-  const [manualOpen, setManualOpen] = useState(true);
 
   return (
     <section>
-      <button
-        type="button"
-        aria-label="Open Manual"
-        className="fixed top-6 right-6 z-50 p-2 rounded-full border shadow-lg transition-colors bg-[--surface-1] border-border hover:bg-[--surface-2]"
-        onClick={() => setManualOpen(true)}
-      >
-        <BookOpen className="w-6 h-6 text-primary" />
-      </button>
       <Manual open={manualOpen} onOpenChange={setManualOpen} />
 
       {selectedWorld && (
@@ -107,6 +130,10 @@ export const Quest = () => {
           )}
         >
           <ButtonsContainer>
+            <ManualButton
+              open={manualOpen}
+              onClick={() => setManualOpen((prev) => !prev)}
+            />
             <ResizeButton
               onClick={() => {
                 setLevelFull((prev) => !prev);
@@ -131,11 +158,6 @@ export const Quest = () => {
           <World worldData={selectedWorldData} isAWorld={true} />
         </section>
       )}
-      {/* WIP
-        <span className="absolute right-4 z-40 py-2 pl-4 bg-[var(--surface-1)]">
-          Manual
-        </span>
-       */}
       <World worldData={worldsData} isAWorld={false} />
     </section>
   );

--- a/src/components/quest/world.jsx
+++ b/src/components/quest/world.jsx
@@ -60,7 +60,7 @@ function World({ worldData, isAWorld }) {
       onMouseMove={handleMouseMove}
       onMouseUp={handleMouseUp}
     >
-      <h2 className="py-2 pl-4 bg-[var(--surface-1)]">
+      <h2 className="py-2 pl-4 font-semibold bg-[var(--surface-1)]">
         {isAWorld ? selectedWorld : "Worlds"}
       </h2>
       <section>

--- a/src/components/ui/textarea.jsx
+++ b/src/components/ui/textarea.jsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Textarea = React.forwardRef(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      ref={ref}
+      {...props} />
+  );
+})
+Textarea.displayName = "Textarea"
+
+export { Textarea }


### PR DESCRIPTION
- **feat(ui): improve manual window and add textarea input**
  Refactors the manual window with better drag/resize handling and
  visual polish. Replaces the Input component with a new Textarea
  component for note-taking. Updates quest and problem preview
  components to use shared button containers and resize/close buttons.
  Adds a new Textarea UI component and improves header styling for
  consistency.
  

- **feat(ui): add manual toggle button and mobile support**
  - Added ManualButton component for toggling the manual window.
  - Integrated manual toggle button into ProblemPreview and Quest panels.
  - Improved Manual window for mobile: disables drag/resize, centers modal,
    and adjusts sizing for small screens.
  - Updated LevelDescription to support skipping code blocks for manual.
  - Refactored imports for consistency and clarity.
  