### PR TITLE
feat(quest): enhance manual, buttons, and world tooltips

### DIFF
--- a/src/components/quest/context.js
+++ b/src/components/quest/context.js
@@ -57,6 +57,27 @@ const QuestProvider = ({ children, initialWorldsData }) => {
     }
   }, []);
 
+  React.useEffect(function setManualOpenFromURL() {
+    const params = new URLSearchParams(location.search);
+    const manualParam = params.get("manual");
+    if (manualParam) {
+      setManualOpen(manualParam === "true");
+    }
+  }, []);
+
+  React.useEffect(
+    function setManualURLParam() {
+      const params = new URLSearchParams(location.search);
+      if (manualOpen) {
+        params.set("manual", "true");
+      } else {
+        params.delete("manual");
+      }
+      history.replaceState({}, "", `${location.pathname}?${params}`);
+    },
+    [manualOpen],
+  );
+
   const updateSelectedWorldData = (worldName) => {
     if (!worldName) {
       setSelectedWorldData([]);

--- a/src/components/quest/manual.jsx
+++ b/src/components/quest/manual.jsx
@@ -3,14 +3,13 @@
 import propTypes from "prop-types";
 import { useContext, useRef, useState, useEffect } from "react";
 import { QuestContext } from "./context";
-import { Button } from "@/components/ui/button";
 import {
   Accordion,
   AccordionItem,
   AccordionTrigger,
   AccordionContent,
 } from "@/components/ui/accordion";
-import { GripVertical, X, CornerDownRight, BookOpen } from "lucide-react";
+import { GripVertical, CircleX, CornerDownRight, BookOpen } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Textarea } from "@/components/ui/textarea";
 import LevelDescription from "./level-description";
@@ -159,6 +158,7 @@ export const Manual = ({ open, onOpenChange }) => {
     if (!dragging && !resizing) return;
 
     const handleMouseMove = (e) => {
+      window.getSelection().removeAllRanges();
       if (dragging) {
         const newX = e.clientX - dragStart.current.x;
         const newY = e.clientY - dragStart.current.y;
@@ -290,14 +290,14 @@ export const Manual = ({ open, onOpenChange }) => {
           )}
           Manual
         </h2>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="rounded-full"
-          onClick={() => onOpenChange(false)}
-        >
-          <X className="w-5 h-5" />
-        </Button>
+        <CircleX
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onOpenChange(false);
+          }}
+          className="w-6 h-6 cursor-pointer hover:text-primary"
+        />
       </header>
       <main className="overflow-y-auto flex-1 py-4 px-4 space-y-6 sm:px-6">
         {unlockedWorlds.length === 0 && (
@@ -327,8 +327,8 @@ export const Manual = ({ open, onOpenChange }) => {
                   {world.name}
                 </span>
               </AccordionTrigger>
-              <AccordionContent>
-                <div className="px-2 pb-2 space-y-4">
+              <AccordionContent className="pb-2">
+                <div className="px-2 space-y-4">
                   {getUnlockedLevels(world).length === 0 && (
                     <div className="pl-2 text-sm text-muted-foreground">
                       No unlocked levels yet.
@@ -357,7 +357,7 @@ export const Manual = ({ open, onOpenChange }) => {
                         }}
                       >
                         <AccordionTrigger className="py-1 px-2 font-semibold rounded">
-                          <span className="flex gap-2 items-center">
+                          <span className="flex gap-2 items-center text-left">
                             <CornerDownRight className="w-4 h-4 text-muted-foreground" />
                             {level.title || level.name}
                           </span>

--- a/src/components/quest/problem-preview.jsx
+++ b/src/components/quest/problem-preview.jsx
@@ -69,8 +69,8 @@ const ProblemPreview = () => {
   };
 
   return (
-    <section className="flex overflow-scroll relative flex-col gap-4 pb-4 h-full">
-      <header className="flex sticky top-0 flex-row gap-4 items-center p-4 shadow-md shadow-background/75 bg-[var(--surface-1)]">
+    <section className="flex overflow-scroll relative flex-col gap-4 h-full">
+      <header className="flex sticky top-0 z-10 flex-row gap-4 items-center p-4 border-b border-[--surface-2] bg-[var(--surface-1)]">
         {selectedLevelData && (
           <WorldNode
             key={selectedLevelName}
@@ -96,7 +96,7 @@ const ProblemPreview = () => {
           <ResizeButton
             onClick={() => setDescriptionFull((prev) => !prev)}
             open={descriptionFull}
-            className="hidden md:block"
+            className="hidden md:flex"
           />
           <CloseButton onClick={closeLevel} />
         </ButtonsContainer>
@@ -104,12 +104,12 @@ const ProblemPreview = () => {
 
       <LevelDescription
         rawHtml={selectedLevelData.description}
-        className="overflow-scroll px-4 prose prose-invert"
+        className="px-4 md:overflow-scroll prose prose-invert"
       />
 
       <footer
         className={cn(
-          "grid gap-4 mx-auto w-full mt-auto max-w-xl px-4 pb-4",
+          "grid gap-4 mx-auto mt-auto w-full max-w-xl p-4 border-t border-[--surface-2]",
           selectedLevelData.leetcode_url && "lg:grid-cols-2 grid-cols-1",
         )}
       >

--- a/src/components/quest/quest.jsx
+++ b/src/components/quest/quest.jsx
@@ -13,7 +13,7 @@ export const ButtonsContainer = ({ children, className }) => {
   return (
     <nav
       className={cn(
-        "absolute right-4 top-[7px] flex items-center justify-center gap-3",
+        "absolute right-4 top-[7px] flex items-center justify-center gap-3 bg-[--surface-1]",
         className,
       )}
     >
@@ -26,30 +26,47 @@ ButtonsContainer.propTypes = {
   className: PropTypes.string,
 };
 
-export const ResizeButton = ({ onClick, className, open }) => {
-  if (open) {
-    return (
-      <Minimize
-        title="Minimize"
-        onClick={onClick}
-        className={cn(
-          "w-6 h-6 ease-in-out cursor-pointer",
-          "hover:text-primary",
-          className,
-        )}
-      />
-    );
-  }
+const AnimatedButton = ({ children, onClick, className, title, ariaLabel }) => {
   return (
-    <Expand
-      aria-label="Maximize"
+    <button
       onClick={onClick}
       className={cn(
-        "w-[24px] h-[24px] cursor-pointer",
-        "hover:text-primary",
+        "flex relative justify-center items-center w-6 h-6 hover:text-primary",
         className,
       )}
-    />
+      title={title}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </button>
+  );
+};
+AnimatedButton.propTypes = {
+  children: PropTypes.node.isRequired,
+  onClick: PropTypes.func.isRequired,
+  className: PropTypes.string,
+  title: PropTypes.string,
+  ariaLabel: PropTypes.string,
+};
+
+export const ResizeButton = ({ onClick, className, open }) => {
+  return (
+    <AnimatedButton
+      aria-label={open ? "Minimize" : "Minimize"}
+      title={open ? "Minimize" : "Maximize"}
+      onClick={onClick}
+      className={className}
+    >
+      <Expand
+        className={cn(
+          "transition-all absolute w-[22px] h-[22px]",
+          open && "opacity-0 scale-0",
+        )}
+      />
+      <Minimize
+        className={cn("transition-all absolute", !open && "opacity-0 scale-50")}
+      />
+    </AnimatedButton>
   );
 };
 ResizeButton.propTypes = {
@@ -73,25 +90,27 @@ CloseButton.propTypes = {
 };
 
 export const ManualButton = ({ open, onClick, className }) => {
-  if (open) {
-    return (
+  return (
+    <AnimatedButton
+      aria-label={open ? "Close Manual" : "Open Manual"}
+      title={open ? "Close Manual" : "Open Manual"}
+      onClick={onClick}
+    >
       <Book
-        aria-label="Close Manual"
-        onClick={onClick}
         className={cn(
-          "w-6 h-6 cursor-pointer",
-          "hover:text-primary",
+          "transition-all absolute",
+          open && "opacity-0 scale-50",
           className,
         )}
       />
-    );
-  }
-  return (
-    <BookOpen
-      aria-label="Open Manual"
-      onClick={onClick}
-      className={cn("w-6 h-6 cursor-pointer", "hover:text-primary", className)}
-    />
+      <BookOpen
+        className={cn(
+          "transition-all absolute",
+          !open && "opacity-0 scale-50",
+          className,
+        )}
+      />
+    </AnimatedButton>
   );
 };
 ManualButton.propTypes = {
@@ -140,7 +159,7 @@ export const Quest = () => {
                 setDescriptionFull(false);
               }}
               open={levelFull}
-              className="hidden md:block"
+              className="hidden md:flex"
             />
             <CloseButton onClick={closeWorld} />
           </ButtonsContainer>
@@ -158,6 +177,12 @@ export const Quest = () => {
           <World worldData={selectedWorldData} isAWorld={true} />
         </section>
       )}
+      <ButtonsContainer>
+        <ManualButton
+          open={manualOpen}
+          onClick={() => setManualOpen((prev) => !prev)}
+        />
+      </ButtonsContainer>
       <World worldData={worldsData} isAWorld={false} />
     </section>
   );

--- a/src/components/quest/quest.jsx
+++ b/src/components/quest/quest.jsx
@@ -29,6 +29,7 @@ ButtonsContainer.propTypes = {
 const AnimatedButton = ({ children, onClick, className, title, ariaLabel }) => {
   return (
     <button
+      type="button"
       onClick={onClick}
       className={cn(
         "flex relative justify-center items-center w-6 h-6 hover:text-primary",
@@ -52,7 +53,7 @@ AnimatedButton.propTypes = {
 export const ResizeButton = ({ onClick, className, open }) => {
   return (
     <AnimatedButton
-      aria-label={open ? "Minimize" : "Minimize"}
+      aria-label={open ? "Minimize" : "Maximize"}
       title={open ? "Minimize" : "Maximize"}
       onClick={onClick}
       className={className}

--- a/src/components/quest/world.jsx
+++ b/src/components/quest/world.jsx
@@ -15,7 +15,13 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { FaCircleCheck, FaLock } from "react-icons/fa6";
+import {
+  FaCircleCheck,
+  FaLightbulb,
+  FaLock,
+  FaPuzzlePiece,
+  FaStar,
+} from "react-icons/fa6";
 
 // also in src/components/arrow.jsx
 const WORLD_WIDTH = 100;
@@ -240,8 +246,8 @@ function WorldNode({
       {!isAPreview && (
         <>
           {!isWorldUnlocked ? (
-            <span className="mt-1 text-[6px]">
-              <FaLock className="inline-block mr-1 w-2 h-2" />
+            <span className="flex gap-x-0.5 items-center mt-1 text-[7px]">
+              <FaLock className="inline-block w-2 h-2" />
               Locked
             </span>
           ) : (
@@ -283,13 +289,15 @@ function LevelTooltipContent({ level }) {
     <TooltipContent className="absolute left-6 space-y-1 w-48 text-xs rounded border-none bg-[--surface-1] shadow-background/75">
       <h4 className="font-semibold">{level.title}</h4>
       <p className="flex gap-1 items-center">
-        <Star className="w-3 h-3 fill-foreground" />
+        {level.type === "LEARN" && <FaLightbulb className="w-3 h-3" />}
+        {level.type === "PROBLEM" && <FaPuzzlePiece className="w-3 h-3" />}
+        {level.type === "BONUS" && <FaStar className="w-3 h-3" />}
         <span>{level.type[0] + level.type.slice(1).toLowerCase()}</span>
       </p>
       <p className="flex gap-1 items-center">
         {level.unlocked ? (
           levelComplete ? (
-            <CheckCircle2 className="w-3 h-3" />
+            <FaCircleCheck className="w-3 h-3" />
           ) : (
             <Circle className="w-3 h-3" />
           )


### PR DESCRIPTION
- Sync manual open state with URL param in quest context
- Refactor manual close button to use CircleX icon
- Animate resize/manual buttons for better UX and a11y
- Improve world/level icons and tooltips for clarity
- Update layout, borders, and z-index for visual polish
- Minor style and className adjustments for consistency
